### PR TITLE
Add support for building a snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "package": "electron-packager . messenger-demo-viewer --out=dist --ignore='^/dist$' --prune --asar --all --icon=build/icon",
     "dist:win": "build -w --ia32 --x64",
     "dist:mac": "build -m",
-    "dist:lin": "build -l deb tar.gz --ia32 --x64",
-    "dist:lin-snap": "build -l snap"
+    "dist:lin": "build -l snap deb tar.gz --ia32 --x64"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "package": "electron-packager . messenger-demo-viewer --out=dist --ignore='^/dist$' --prune --asar --all --icon=build/icon",
     "dist:win": "build -w --ia32 --x64",
     "dist:mac": "build -m",
-    "dist:lin": "build -l deb tar.gz --ia32 --x64"
+    "dist:lin": "build -l deb tar.gz --ia32 --x64",
+    "dist:lin-snap": "build -l snap"
   },
   "files": [
     "index.js"
@@ -34,7 +35,7 @@
   },
   "devDependencies": {
     "electron": "^1.7.8",
-    "electron-builder": "^19.33.0",
+    "electron-builder": "^19.53.0",
     "electron-debug": "^1.4.0",
     "electron-packager": "^9.1.0",
     "eslint": "^4.8.0",
@@ -50,7 +51,10 @@
     },
     "win": {},
     "linux": {
-      "category": "Network"
+      "category": "Network",
+      "target": [
+        "snap"
+      ]
     }
   }
 }


### PR DESCRIPTION
I've put together this pull request to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist:lin-snap` on an Ubuntu 16.04 VM with an [appropriate version of node installed](https://github.com/nodesource/distributions) it will create `dist/messenger-demo-viewer_1.0.1_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous messenger-demo-viewer_1.0.1_amd64.snap`. Execute it with `messenger-demo-viewer` from the terminal or find it in the desktop launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "messenger-demo-viewer" name](https://dashboard.snapcraft.io/register-snap/?name=messenger-demo-viewer).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push it to the store out with:
`snapcraft push messenger-demo-viewer_1.0.1_amd64.snap --release stable`